### PR TITLE
cambios visuales

### DIFF
--- a/front/src/components/dashboard/MetricsDashboard.tsx
+++ b/front/src/components/dashboard/MetricsDashboard.tsx
@@ -263,6 +263,13 @@ export default function MetricsDashboard({
     };
   }, []);
 
+  const hasUploadedData =
+  topProducts.length > 0 ||
+  topProfitableProducts.length > 0 ||
+  weatherImpactIncome.length > 0 ||
+  calendarImpactIncome.length > 0 ||
+  categoryProfitability.length > 0;
+
   const handleDragEnd = (e: DragEndEvent) => {
     const { active, over } = e;
     if (over && active.id !== over.id) {
@@ -272,6 +279,8 @@ export default function MetricsDashboard({
 
   return (
     <>
+    {hasUploadedData ? (
+      <div>
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-4">
         <UpliftKpiCard
           title="Incremento por feriado"
@@ -332,9 +341,8 @@ export default function MetricsDashboard({
           <CategoryProfitabilityChart data={categoryProfitability} />
         </MetricCard>
       </div>
-
-
-      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+      
+        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
         <SortableContext items={metrics.map(m => m.id)} strategy={rectSortingStrategy}>
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
             <AnimatePresence>
@@ -345,6 +353,17 @@ export default function MetricsDashboard({
           </div>
         </SortableContext>
       </DndContext>
+      </div>
+      ) : (<div>
+            <h3 className="text-lg font-semibold text-card-foreground mb-2">
+            No hay datos cargados
+            </h3>
+
+            <p className="text-sm text-muted-foreground">
+            Sube un archivo para visualizar métricas personalizadas.
+            </p>
+      </div>)
+      }
 
       <button
         onClick={() => setShowAdd(true)}

--- a/front/src/components/dashboard/PredictionsView.tsx
+++ b/front/src/components/dashboard/PredictionsView.tsx
@@ -17,14 +17,6 @@ const DAILY_DATA = [
   { day: 'Dom', predicted: 1440 },
 ];
 
-const HEATMAP_DATA = [
-  { product: 'Leche Organica', mon: 48, tue: 45, wed: 52, thu: 49, fri: 58, sat: 62, sun: 50 },
-  { product: 'Pan de Masa Madre', mon: 42, tue: 39, wed: 44, thu: 41, fri: 50, sat: 55, sun: 43 },
-  { product: 'Huevos', mon: 38, tue: 36, wed: 42, thu: 39, fri: 46, sat: 52, sun: 40 },
-  { product: 'Paltas', mon: 35, tue: 32, wed: 38, thu: 36, fri: 42, sat: 48, sun: 37 },
-  { product: 'Yogur', mon: 33, tue: 30, wed: 36, thu: 34, fri: 40, sat: 44, sun: 35 },
-];
-
 const DAYS = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'] as const;
 const DAYS_LABEL: Record<(typeof DAYS)[number], string> = {
   mon: 'Lun',
@@ -112,15 +104,14 @@ export default function PredictionsView({ selectedStoreId }: PredictionsViewProp
   const [view, setView] = useState<'aggregated' | 'detailed'>('aggregated');
   const [isLoading, setIsLoading] = useState(false);
   const [lastPredictionDate, setLastPredictionDate] = useState<Date | null>(null);
-  const [backendHeatmap, setBackendHeatmap] = useState<HeatmapRow[]>(HEATMAP_DATA);
+  const [backendHeatmap, setBackendHeatmap] = useState<HeatmapRow[]>([]);
   const [predictMessage, setPredictMessage] = useState<string>('');
 
-  const heatmapData = useMemo(() => {
-    return backendHeatmap.length > 0 ? backendHeatmap : HEATMAP_DATA;
-  }, [backendHeatmap]);
+  const heatmapData = backendHeatmap;
 
   const totalPredicted = DAILY_DATA.reduce((sum, d) => sum + d.predicted, 0);
   const highestDay = DAILY_DATA.reduce((max, d) => d.predicted > max.predicted ? d : max, DAILY_DATA[0]);
+  const hasPredictions = backendHeatmap.length > 0;
 
   const handleGeneratePredictions = async () => {
     setIsLoading(true);
@@ -157,8 +148,19 @@ export default function PredictionsView({ selectedStoreId }: PredictionsViewProp
       {predictMessage && (
         <p className="text-xs text-muted-foreground">{predictMessage}</p>
       )}
+      {!hasPredictions ? (
+        <div className="rounded-xl border border-dashed border-border bg-card p-10 text-center">
+          <h3 className="text-lg font-semibold mb-2">
+            No hay predicciones generadas
+          </h3>
 
-      {/* Toggle */}
+          <p className="text-sm text-muted-foreground">
+            Genera predicciones para visualizar análisis y demanda estimada.
+          </p>
+        </div>
+      ) : (
+        <>
+              {/* Toggle */}
       <div className="flex items-center gap-2">
         <button
           onClick={() => setView('aggregated')}
@@ -296,6 +298,8 @@ export default function PredictionsView({ selectedStoreId }: PredictionsViewProp
             </table>
           </div>
         </div>
+      )}
+        </>
       )}
     </div>
   );

--- a/front/src/components/dashboard/TopBar.tsx
+++ b/front/src/components/dashboard/TopBar.tsx
@@ -20,7 +20,7 @@ export default function TopBar({
   storeName,
 }: TopBarProps) {
   return (
-    <div className="flex items-center justify-between mb-6">
+    <div className="flex items-center justify-between mb-6 border-r-4 border-b-4 border-gray-500 sticky top-0 z-50 bg-white p-12 rounded">
       <div>
         <h2 className="text-lg font-bold text-foreground tracking-tight">{storeName}</h2>
         <p className="text-xs text-muted-foreground capitalize">Vista de {viewMode === 'metrics' ? 'metricas' : 'predicciones'}</p>

--- a/front/src/components/dashboard/UploadDataModal.tsx
+++ b/front/src/components/dashboard/UploadDataModal.tsx
@@ -74,6 +74,11 @@ export default function UploadDataModal({ open, onOpenChange, storeId }: UploadD
         });
         onOpenChange(false);
         resetState();
+
+        setTimeout(() => {
+          window.location.reload();
+        }, 1000);
+
         return;
       }
 


### PR DESCRIPTION
Apunto a predictGPT en lugar de main porque predictGPT y main aún tienen cambios por resolver.
- Los datos hardcodeados de Metrics y Predictions no se ven hasta que se carguen los datos y se genere la predicción.
- La pagina se refresca ni bien se suben los datos al back.
- La barra superior ahora es un sticky que se sigue viendo al scrollear.